### PR TITLE
feat: Use vendor/package namespace convention. Move service to infras…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor
 bin
+build
 .idea
 *.swp

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Ulabox\\": "src/"
+      "Ulabox\\SystemClock\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Ulabox\\Tests\\": "tests/"
+      "Ulabox\\Tests\\SystemClock\\": "tests/"
     }
   },
   "config": {

--- a/src/Infrastructure/SystemClock.php
+++ b/src/Infrastructure/SystemClock.php
@@ -1,8 +1,10 @@
 <?php
 
-namespace Ulabox;
+namespace Ulabox\SystemClock\Infrastructure;
 
-class Clock implements SystemClock
+use Ulabox\SystemClock\SystemClock as SystemClockInterface;
+
+class SystemClock implements SystemClockInterface
 {
     /**
      * @return \DateTimeImmutable

--- a/src/SystemClock.php
+++ b/src/SystemClock.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Ulabox;
+namespace Ulabox\SystemClock;
 
 interface SystemClock
 {

--- a/tests/Unit/Infrastructure/SystemClockTest.php
+++ b/tests/Unit/Infrastructure/SystemClockTest.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Ulabox\Tests\Unit;
+namespace Ulabox\Tests\SystemClock\Infrastructure;
 
-use Ulabox\SystemClock;
-use Ulabox\Clock;
+use Ulabox\SystemClock\Infrastructure\SystemClock;
+use Ulabox\SystemClock\SystemClock as SystemClockInterface;
 
-class ClockTest extends \PHPUnit_Framework_TestCase
+class SystemClockTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var SystemClock
@@ -14,12 +14,12 @@ class ClockTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->sut = new Clock();
+        $this->sut = new SystemClock();
     }
 
     public function testImplementsSystemClockInterface()
     {
-        $this->assertInstanceOf(SystemClock::class, $this->sut);
+        $this->assertInstanceOf(SystemClockInterface::class, $this->sut);
     }
 
     public function testReturnsDateTimeImmutables()


### PR DESCRIPTION
With the current implementation both _SystemClock_ interface and _Clock_ class reside on the _Ulabox_ vendor namespace. IMHO this might lead to collisions with other packages of our own if we keep it as a naming rule, and we should use _vendor/package_ prefix convention instead.

On another subject, I find it really annoying to name the SystemClock _"Clock"_ just because we want to avoid using the _Interface_ suffix. To avoid this, I've moved the "Clock" class to the Infrastructure namespace and renamed it to SystemClock, adjusting the tests accordingly.

**This is a *BC BREAKING* change.**